### PR TITLE
Cambia 'no tiene wsp' por 'no pudo ser contactado'

### DIFF
--- a/src/components/Feedback/Alerts/Alerts.tsx
+++ b/src/components/Feedback/Alerts/Alerts.tsx
@@ -31,7 +31,7 @@ const Alerts = () => {
         <div className="MensajeSinWhatsapp__dialogo_contenido">
           <p>
             Desde ahora en Feedback estamos marcando los números de teléfono de
-            pacientes que no usan WhatsApp
+            pacientes que no pudimos contactar por no tener Whatsapp u otros motivos.
           </p>
           <form method="dialog">
             <button className="MensajeSinWhatsapp__boton_cerrar_dialogo">

--- a/src/components/Feedback/InteractionDrawer/Smartphone/SmartphoneUnreachableMessage/SmartphoneUnreachableMessage.tsx
+++ b/src/components/Feedback/InteractionDrawer/Smartphone/SmartphoneUnreachableMessage/SmartphoneUnreachableMessage.tsx
@@ -15,9 +15,6 @@ const SmartphoneUnreachableMessage = () => {
         <h3 className="SmartphoneUnreachableMessage__title">
           No pudimos contactar a este paciente
         </h3>
-        <p className="SmartphoneUnreachableMessage__content">
-          El número asociado no tiene Whatsapp
-        </p>
       </div>
     </div>
   )

--- a/src/components/Feedback/Respuestas/Chat/CelularWhatsapp/MensajeSinWhatsapp/MensajeSinWhatsapp.js
+++ b/src/components/Feedback/Respuestas/Chat/CelularWhatsapp/MensajeSinWhatsapp/MensajeSinWhatsapp.js
@@ -14,7 +14,7 @@ const MensajeSinWhatsapp = ({ start, intentos }) => {
           </div>
           <p>
             Desde ahora en Feedback estamos marcando los números de teléfono de
-            pacientes que no usan WhatsApp
+            pacientes que no pudimos contactar por no tener Whatsapp u otros motivos.
           </p>
           <form method="dialog">
             <button className="MensajeSinWhatsapp__boton_cerrar_dialogo">
@@ -56,7 +56,7 @@ const MensajeSinWhatsapp = ({ start, intentos }) => {
             </>
           ) : (
             // xx aqui hay que modificar
-            <>El número asociado no tiene Whatsapp</>
+            <></>
           )}
         </p>
       </div>


### PR DESCRIPTION
Ahora que estamos ocupando el error 63024 para marcar unreachable, no es siempre que los pacientes no tengan Whatsapp, así que dejaremos un mensaje más general