### PR TITLE
Agrega mensaje "no contactado" en búsqueda

### DIFF
--- a/src/api/hooks/useChatQuery.ts
+++ b/src/api/hooks/useChatQuery.ts
@@ -11,6 +11,7 @@ import {
   Appointment,
   Interaction,
   InteractionId,
+  InteractionTag,
   Message,
   SchedulingSystem,
 } from '../types/domain'
@@ -206,6 +207,9 @@ const conversationToInteraction = (
 ): Interaction => {
   const { serviceId, patientId, start } = interactionId
   const { context, messages } = conversation
+  let tags :Array<InteractionTag> = []
+  if (conversation.is_unreachable.whatsapp || conversation.is_unreachable.phone)
+    tags.push('UNREACHABLE_WHATSAPP')
   const interaction: Interaction = {
     id: {
       patientId: patientId,
@@ -231,7 +235,7 @@ const conversationToInteraction = (
       header: meta.title,
       value: meta.value,
     })),
-    tags: [],
+    tags: tags,
   }
   return interaction
 }

--- a/src/api/types/responses.ts
+++ b/src/api/types/responses.ts
@@ -70,7 +70,7 @@ export interface ChatAPIConversation {
       tag: string
     }
   ]
-  is_unreachable: { whatsapp: boolean }
+  is_unreachable: { whatsapp: boolean, phone: boolean}
 }
 
 export interface ChatAPIResponse {


### PR DESCRIPTION
Cuando un número no puede ser contactado tenemos el mensaje en el chat de las respuestas pero no en el chat de la búsqueda.
Ahora también aparece en la búsqueda