### PR TITLE
Fix banner deuda

### DIFF
--- a/src/components/Feedback/PaymentDueModal/PaymentDueModal.tsx
+++ b/src/components/Feedback/PaymentDueModal/PaymentDueModal.tsx
@@ -13,6 +13,7 @@ const PaymentDueModal = () => {
   if (
     isLoading ||
     !visible ||
+    data === undefined ||
     esCero(cuenta) ||
     data?.status === 'NOT_EXPIRED'
   ) {


### PR DESCRIPTION
## Resumen
Para no mostrar el banner de deuda asumimos obtenemos respuesta desde pipedream.
Entonces si pipedream no nos responde mostamos un mensaje cuando no debemos (imagen al final)

## Detalles del cambio
Este cambio revisa que si la respuesta es `undefined` no mostremos el banner


![image (8)](https://github.com/ceroai/botlab-feedback/assets/829975/19fff46e-f23f-48da-938a-01c521ca1c2f)

